### PR TITLE
tre sekunder er bedre

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -1,24 +1,24 @@
 /*
   Blink
   Turns on an LED on for one second, then off for one second, repeatedly.
- 
+
   This example code is in the public domain.
  */
- 
+
 // Pin 13 has an LED connected on most Arduino boards.
 // give it a name:
 int led = 13;
 
 // the setup routine runs once when you press reset:
-void setup() {                
+void setup() {
   // initialize the digital pin as an output.
-  pinMode(led, OUTPUT);     
+  pinMode(led, OUTPUT);
 }
 
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
+  delay(3000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(2000);               // wait for a second
+  delay(3000);               // wait for a second
 }


### PR DESCRIPTION
Studies have not shown that 3 seconds is a far better LED delay than 1 second.

I am, however, following a simple forking and pull request guide, and therefore this change was made. No other reason.