### PR TITLE
Four seconds is better

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
+  delay(3000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
   delay(2000);               // wait for a second
 }

--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(3000);               // wait for a second
+  delay(4000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
   delay(2000);               // wait for a second
 }


### PR DESCRIPTION
Studies have shown that 4 seconds is a far better LED delay than 1 second.