### PR TITLE
Change delay to 3 seconds

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
+  delay(3000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(1000);               // wait for a second
+  delay(3000);               // wait for a second
 }


### PR DESCRIPTION
### Overview
This pull request updates the `blink.ino` file to increase the delay between LED blinks from 1 second to 3 seconds.

### Changes Made
- Modified the `delay` function calls in the `loop()` function:
  - Changed from `delay(1000);` to `delay(3000);`.

### Rationale
The original delay of 1 second between LED blinks was quite fast for the intended visual effect. Increasing the delay to 3 seconds makes the blinking rate more noticeable and suitable for longer visual intervals.

### Testing
- Verified the change by running the updated code on an Arduino board.
- Confirmed that the LED blinks with a 3-second interval as expected.

Please review the changes and let me know if any additional modifications are required. Thank you!
