### PR TITLE
Increase delays to 3 seconds

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(1000);               // wait for a second
+  delay(3000);               // wait for a second
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(2000);               // wait for a second
+  delay(3000);               // wait for a second
 }


### PR DESCRIPTION
The default 'LED on' delay of 1 second and 'LED on' delay of 2 seconds are too fast. A 3 second delay on both is much better.